### PR TITLE
#452 use long RF support in RFMonitorBlockTileEntity

### DIFF
--- a/src/main/java/mcjty/rftools/blocks/monitor/RFMonitorBlockTileEntity.java
+++ b/src/main/java/mcjty/rftools/blocks/monitor/RFMonitorBlockTileEntity.java
@@ -140,7 +140,7 @@ public class RFMonitorBlockTileEntity extends GenericTileEntity {
             setInvalid();
             return;
         }
-        EnergyTools.EnergyLevel energy = EnergyTools.getEnergyLevel(tileEntity);
+        EnergyTools.EnergyLevelMulti energy = EnergyTools.getEnergyLevelMulti(tileEntity);
         long maxEnergy = energy.getMaxEnergy();
         int ratio = 0;  // Will be set as metadata;
         boolean alarm = false;


### PR DESCRIPTION
Use the existing Multiblock support also in RFMonitorBlockTileEntity. Fixes #452.

Note for testing: EnderIO scales its int RF value to its current long value. This means that the  RF Monitor already works correctly with EnderIO capacitors as the conversion is done by EnderIO. Draconic Evolution does not scale its value and truncates it.