### PR TITLE
Allow RegEx in the RF Network Monitor

### DIFF
--- a/src/main/java/mcjty/rftools/items/netmonitor/GuiNetworkMonitor.java
+++ b/src/main/java/mcjty/rftools/items/netmonitor/GuiNetworkMonitor.java
@@ -196,8 +196,14 @@ public class GuiNetworkMonitor extends GuiItemScreen {
                 String displayName = BlockInfo.getReadableName(block, coordinate, meta, mc.theWorld);
 
                 if (filter != null) {
-                    if (!displayName.toLowerCase().contains(filter)) {
-                        continue;
+                    try {
+                        if (!Pattern.matches(filter, displayName.toLowerCase())) {
+                            continue;
+                        }
+                    } catch (Exception e) {
+                        if (!displayName.contains(filter)) {
+                            continue;
+                        }
                     }
                 }
 


### PR DESCRIPTION
Allows the use of regular expressions in the RF Network Monitor to give users who are familiar with regular expressions more power in their filters. This should not affect users who do not know RegEx except in rare cases (when regex special characters are unintentionally used, which is extremely rare, especially in Minecraft).
