### PR TITLE
Allow sensors to detect fluids (#829)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.iws
 eclipse/
 out/
+/bin/

--- a/src/main/java/mcjty/rftools/blocks/logic/sensor/SensorTileEntity.java
+++ b/src/main/java/mcjty/rftools/blocks/logic/sensor/SensorTileEntity.java
@@ -119,12 +119,12 @@ public class SensorTileEntity extends LogicTileEntity implements ITickable, Defa
         BlockPos newpos = getPos().offset(inputSide);
 
         switch (sensorType) {
-	        case SENSOR_BLOCK:
-	            newout = checkBlockOrFluid(newpos, inputSide, (pos) -> checkBlock(pos));
-	            break;
-	        case SENSOR_FLUID:
-	            newout = checkBlockOrFluid(newpos, inputSide, (pos) -> checkFluid(pos));
-	            break;
+            case SENSOR_BLOCK:
+                newout = checkBlockOrFluid(newpos, inputSide, (pos) -> checkBlock(pos));
+                break;
+            case SENSOR_FLUID:
+                newout = checkBlockOrFluid(newpos, inputSide, (pos) -> checkFluid(pos));
+                break;
             case SENSOR_GROWTHLEVEL:
                 newout = checkGrowthLevel(newpos, inputSide);
                 break;
@@ -180,46 +180,46 @@ public class SensorTileEntity extends LogicTileEntity implements ITickable, Defa
         ItemStack matcher = inventoryHelper.getStackInSlot(0);
         Block block = state.getBlock();
         if (matcher == null) {
-        	if (block instanceof BlockLiquid || block instanceof IFluidBlock) {
-        		return !block.isAir(state, worldObj, newpos);
-        	}
-        	
+            if (block instanceof BlockLiquid || block instanceof IFluidBlock) {
+                return !block.isAir(state, worldObj, newpos);
+            }
+
             return false;
         }
         ItemStack stack = block.getItem(worldObj, newpos, state);
         Item matcherItem = matcher.getItem();
-        
+
         FluidStack matcherFluidStack = null;
         if (matcherItem instanceof IFluidContainerItem) {
-	    	matcherFluidStack = ((IFluidContainerItem)matcherItem).getFluid(matcher);
-	    	return checkFluid(block, matcherFluidStack, state, newpos);
+            matcherFluidStack = ((IFluidContainerItem)matcherItem).getFluid(matcher);
+            return checkFluid(block, matcherFluidStack, state, newpos);
         } else if (matcherItem instanceof ItemBucket || matcherItem instanceof UniversalBucket) {
-	    	matcherFluidStack = new FluidBucketWrapper(matcher).getFluid();
-	    	return checkFluid(block, matcherFluidStack, state, newpos);
-	    }
+            matcherFluidStack = new FluidBucketWrapper(matcher).getFluid();
+            return checkFluid(block, matcherFluidStack, state, newpos);
+        }
 
         return false;
     }
 
-	private boolean checkFluid(Block block, FluidStack matcherFluidStack, IBlockState state, BlockPos newpos) {
-	    if (matcherFluidStack == null) {
-    		return block.isAir(state,  worldObj, newpos);
-	    }
+    private boolean checkFluid(Block block, FluidStack matcherFluidStack, IBlockState state, BlockPos newpos) {
+        if (matcherFluidStack == null) {
+            return block.isAir(state,  worldObj, newpos);
+        }
 
-	    Fluid matcherFluid = matcherFluidStack.getFluid();
-    	if (matcherFluid == null) {
-    		return false;
-    	}
-	    	
-		Block matcherFluidBlock = matcherFluid.getBlock();
-		if (matcherFluidBlock == null) {
-			return false;
-		}
-		
-		String matcherBlockName = matcherFluidBlock.getUnlocalizedName();
-		String blockName = block.getUnlocalizedName();
-		return blockName.equals(matcherBlockName);
-	}
+        Fluid matcherFluid = matcherFluidStack.getFluid();
+        if (matcherFluid == null) {
+            return false;
+        }
+
+        Block matcherFluidBlock = matcherFluid.getBlock();
+        if (matcherFluidBlock == null) {
+            return false;
+        }
+
+        String matcherBlockName = matcherFluidBlock.getUnlocalizedName();
+        String blockName = block.getUnlocalizedName();
+        return blockName.equals(matcherBlockName);
+    }
 
     private boolean checkGrowthLevel(BlockPos newpos, EnumFacing dir) {
         int blockCount = areaType.getBlockCount();

--- a/src/main/java/mcjty/rftools/blocks/logic/sensor/SensorTileEntity.java
+++ b/src/main/java/mcjty/rftools/blocks/logic/sensor/SensorTileEntity.java
@@ -174,10 +174,10 @@ public class SensorTileEntity extends LogicTileEntity implements ITickable, Defa
         FluidStack matcherFluidStack = null;
         if (matcherItem instanceof IFluidContainerItem) {
 	    	matcherFluidStack = ((IFluidContainerItem)matcherItem).getFluid(matcher);
-	    	return checkFluid(block, matcherFluidStack);
+	    	return checkFluid(block, matcherFluidStack, state, newpos);
         } else if (matcherItem instanceof ItemBucket || matcherItem instanceof UniversalBucket) {
 	    	matcherFluidStack = new FluidBucketWrapper(matcher).getFluid();
-	    	return checkFluid(block, matcherFluidStack);
+	    	return checkFluid(block, matcherFluidStack, state, newpos);
 	    } else if (stack != null) {
         	Item stackItem = stack.getItem();
             return matcherItem == stackItem;
@@ -187,9 +187,9 @@ public class SensorTileEntity extends LogicTileEntity implements ITickable, Defa
         }
     }
 
-	private boolean checkFluid(Block block, FluidStack matcherFluidStack) {
+	private boolean checkFluid(Block block, FluidStack matcherFluidStack, IBlockState state, BlockPos newpos) {
 	    if (matcherFluidStack == null) {
-    		return false;
+    		return block.isAir(state,  worldObj, newpos);
 	    }
 
 	    Fluid matcherFluid = matcherFluidStack.getFluid();

--- a/src/main/java/mcjty/rftools/blocks/logic/sensor/SensorTileEntity.java
+++ b/src/main/java/mcjty/rftools/blocks/logic/sensor/SensorTileEntity.java
@@ -168,13 +168,21 @@ public class SensorTileEntity extends LogicTileEntity implements ITickable, Defa
         ItemStack stack = block.getItem(worldObj, newpos, state);
         Item matcherItem = matcher.getItem();
         
-    	FluidBucketWrapper wrapper = new FluidBucketWrapper(matcher);
-    	FluidStack fluidStack = wrapper.getFluid();
-	    if (fluidStack != null) {
-	    	Fluid fluid = fluidStack.getFluid();
-			Block fluidBlock = fluid.getBlock();
-			boolean isSameFluid = fluidBlock != null && fluidBlock.getUnlocalizedName().equals(block.getUnlocalizedName());
-			return isSameFluid;
+    	FluidStack matcherFluidStack = new FluidBucketWrapper(matcher).getFluid();
+	    if (matcherFluidStack != null) {
+	    	Fluid matcherFluid = matcherFluidStack.getFluid();
+	    	if (matcherFluid == null) {
+	    		return false;
+	    	}
+	    	
+    		Block matcherFluidBlock = matcherFluid.getBlock();
+    		if (matcherFluidBlock == null) {
+    			return false;
+    		}
+    		
+			String matcherBlockName = matcherFluidBlock.getUnlocalizedName();
+			String blockName = block.getUnlocalizedName();
+			return blockName.equals(matcherBlockName);
 	    } else if (stack != null) {
         	Item stackItem = stack.getItem();
             return matcherItem == stackItem;

--- a/src/main/java/mcjty/rftools/blocks/logic/sensor/SensorTileEntity.java
+++ b/src/main/java/mcjty/rftools/blocks/logic/sensor/SensorTileEntity.java
@@ -6,6 +6,7 @@ import mcjty.lib.network.Argument;
 import mcjty.rftools.blocks.logic.generic.LogicTileEntity;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockCrops;
+import net.minecraft.block.BlockLiquid;
 import net.minecraft.block.BlockNetherWart;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
@@ -158,16 +159,15 @@ public class SensorTileEntity extends LogicTileEntity implements ITickable, Defa
         ItemStack matcher = inventoryHelper.getStackInSlot(0);
         Block block = state.getBlock();
         if (matcher == null) {
+        	if (block instanceof BlockLiquid || block instanceof BlockFluidBase) {
+        		return !block.isAir(state, worldObj, newpos);
+        	}
+        	
             return block.isFullBlock(state);
         }
         ItemStack stack = block.getItem(worldObj, newpos, state);
         Item matcherItem = matcher.getItem();
         
-    	// We could test whether the fluid is a liquid or a gas.
-    	// There doesn't seem to be a downside to allowing this method to match gases, though.
-    	// Gases can't be placed as blocks and so this code shouldn't be called anyway.
-    	// Even if someone does manage to do it, it would make sense for them to be able to match the gas
-    	// if they manage to store a bucket containing a gas in the sensor's filter slot.
     	FluidBucketWrapper wrapper = new FluidBucketWrapper(matcher);
     	FluidStack fluidStack = wrapper.getFluid();
 	    if (fluidStack != null) {

--- a/src/main/java/mcjty/rftools/blocks/logic/sensor/SensorType.java
+++ b/src/main/java/mcjty/rftools/blocks/logic/sensor/SensorType.java
@@ -4,6 +4,7 @@ import mcjty.rftools.varia.NamedEnum;
 
 public enum SensorType implements NamedEnum {
     SENSOR_BLOCK("Block", false, true, "Detect if a certain type", "of block is present"),
+    SENSOR_FLUID("Fluid", false, true, "Detect if a certain type", "of fluid is present"),
     SENSOR_GROWTHLEVEL("Growth", true, true, "Detect the growth percentage", "of a crop"),
     SENSOR_ENTITIES("Entities", true, false, "Count the amount of entities"),
     SENSOR_PLAYERS("Players", true, false, "Count the amount of players"),


### PR DESCRIPTION
This allows sensors to detect fluids when in a new Fluid mode as per #829. Users can filter the fluid detected by using a bucket or any compatible third-party fluid container.

I chose to add a new Fluid mode for backward compatibility; changing the Block mode could have broken devices which rely on it not detecting fluids. I don't know how common such devices are in practice, though. I think that adding functionality to the Block mode would be less confusing to new users, plus it wouldn't be possible to accidentally use a fluid filter in Block mode or a block filter in Fluid mode.

Using an empty bucket or fluid container in the filter detects air blocks. This was done for consistency with the filled containers and makes sense if you think about the fact that an empty bucket contains air.

Comments/questions/concerns?