### PR TITLE
Tweaked Spawner to be able to summon a functioning ender dragon

### DIFF
--- a/src/main/java/mcjty/rftools/blocks/spawner/SpawnerTileEntity.java
+++ b/src/main/java/mcjty/rftools/blocks/spawner/SpawnerTileEntity.java
@@ -15,6 +15,7 @@ import net.minecraft.entity.EntityList;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.monster.EntitySkeleton;
 import net.minecraft.entity.monster.SkeletonType;
+import net.minecraft.entity.boss.EntityDragon;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -245,7 +246,13 @@ public class SpawnerTileEntity extends GenericEnergyReceiverTileEntity implement
             } else if (entityLiving instanceof EntitySkeleton) {
                 // Force non-wither otherwise
                 ((EntitySkeleton) entityLiving).setSkeletonType(SkeletonType.NORMAL);
-            }
+            } else if (entityLiving instanceof EntityDragon) {
+		// Ender dragon needs to be spawned with an additional NBT key set
+		NBTTagCompound dragonTag = new NBTTagCompound();
+		entityLiving.writeEntityToNBT(dragonTag);
+		dragonTag.setShort("DragonPhase", (short)0);
+		entityLiving.readEntityFromNBT(dragonTag);
+	    }
         } catch (InstantiationException e) {
             Logging.logError("Fail to spawn mob: " + mobId);
             return;


### PR DESCRIPTION
In order for the ender dragon to have a functioning AI when it's spawned, it needs a data tag set on it.

See http://minecraft.gamepedia.com/Ender_Dragon#Data_values for reference

Other information that may be useful to know...  Shields don't contain her (She noclips through them) and it seems that she flies towards X=0, Z=0. I suspect this is hard coded in her AI.