### PR TITLE
Add a sensor mode which treats individual dropped items as separate, unlike the Entities mode (#876)

### DIFF
--- a/src/main/java/mcjty/rftools/blocks/logic/sensor/SensorTileEntity.java
+++ b/src/main/java/mcjty/rftools/blocks/logic/sensor/SensorTileEntity.java
@@ -273,19 +273,26 @@ public class SensorTileEntity extends LogicTileEntity implements ITickable, Defa
     }
     
     private boolean checkItems(BlockPos pos1, EnumFacing dir) {
-        List<EntityItem> items = worldObj.getEntitiesWithinAABB(EntityItem.class, getCachedBox(pos1, dir));
-        int entityCount = items.stream().mapToInt(item -> getEntityItemStackSize(item)).sum();
+        ItemStack matcher = inventoryHelper.getStackInSlot(0);
+        Item matcherItem = (matcher == null) ? null : matcher.getItem();
 
+        List<EntityItem> items = worldObj.getEntitiesWithinAABB(EntityItem.class, getCachedBox(pos1, dir));
+        int entityCount = items.stream().mapToInt(item -> getEntityItemStackSize(item, matcherItem)).sum();
+        
         return entityCount >= number;
     }
     
-    private int getEntityItemStackSize(EntityItem entityItem) {
+    private int getEntityItemStackSize(EntityItem entityItem, Item matcherItem) {
         if (entityItem == null) {
             return 0;
         }
         
         ItemStack stack = entityItem.getEntityItem();
         if (stack == null) {
+            return 0;
+        }
+        
+        if (matcherItem != null && matcherItem != stack.getItem()) {
             return 0;
         }
 

--- a/src/main/java/mcjty/rftools/blocks/logic/sensor/SensorTileEntity.java
+++ b/src/main/java/mcjty/rftools/blocks/logic/sensor/SensorTileEntity.java
@@ -27,7 +27,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.fluids.*;
 import net.minecraftforge.fluids.capability.wrappers.FluidBucketWrapper;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;

--- a/src/main/java/mcjty/rftools/blocks/logic/sensor/SensorTileEntity.java
+++ b/src/main/java/mcjty/rftools/blocks/logic/sensor/SensorTileEntity.java
@@ -11,6 +11,7 @@ import net.minecraft.block.BlockNetherWart;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityCreature;
+import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.monster.IMob;
 import net.minecraft.entity.passive.IAnimals;
 import net.minecraft.entity.player.EntityPlayer;
@@ -26,6 +27,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.fluids.*;
 import net.minecraftforge.fluids.capability.wrappers.FluidBucketWrapper;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -128,6 +130,9 @@ public class SensorTileEntity extends LogicTileEntity implements ITickable, Defa
                 break;
             case SENSOR_ENTITIES:
                 newout = checkEntities(newpos, inputSide, Entity.class);
+                break;
+            case SENSOR_ITEMS:
+                newout = checkItems(newpos, inputSide);
                 break;
             case SENSOR_PLAYERS:
                 newout = checkEntities(newpos, inputSide, EntityPlayer.class);
@@ -266,7 +271,27 @@ public class SensorTileEntity extends LogicTileEntity implements ITickable, Defa
         }
         return cachedBox;
     }
+    
+    private boolean checkItems(BlockPos pos1, EnumFacing dir) {
+        List<EntityItem> items = worldObj.getEntitiesWithinAABB(EntityItem.class, getCachedBox(pos1, dir));
+        int entityCount = items.stream().mapToInt(item -> getEntityItemStackSize(item)).sum();
 
+        return entityCount >= number;
+    }
+    
+    private int getEntityItemStackSize(EntityItem entityItem) {
+        if (entityItem == null) {
+            return 0;
+        }
+        
+        ItemStack stack = entityItem.getEntityItem();
+        if (stack == null) {
+            return 0;
+        }
+
+        return stack.stackSize;
+    }
+    
     private boolean checkEntities(BlockPos pos1, EnumFacing dir, Class<? extends Entity> clazz) {
         List<Entity> entities = worldObj.getEntitiesWithinAABB(clazz, getCachedBox(pos1, dir));
         return entities.size() >= number;

--- a/src/main/java/mcjty/rftools/blocks/logic/sensor/SensorType.java
+++ b/src/main/java/mcjty/rftools/blocks/logic/sensor/SensorType.java
@@ -7,6 +7,7 @@ public enum SensorType implements NamedEnum {
     SENSOR_FLUID("Fluid", false, true, "Detect if a certain type", "of fluid is present"),
     SENSOR_GROWTHLEVEL("Growth", true, true, "Detect the growth percentage", "of a crop"),
     SENSOR_ENTITIES("Entities", true, false, "Count the amount of entities"),
+    SENSOR_ITEMS("Items", true, false, "Count the amount of items"),
     SENSOR_PLAYERS("Players", true, false, "Count the amount of players"),
     SENSOR_HOSTILE("Hostile", true, false, "Count the amount of hostile mobs"),
     SENSOR_PASSIVE("Passive", true, false, "Count the amount of passive mobs");


### PR DESCRIPTION
The reporter of #876 attempted to use a filter in Entities mode. That doesn't actually do anything, but providing a filter in Items mode will work as expected.