### PR TITLE
Fixed OpenComputers being unable to dial to any other dimension

### DIFF
--- a/src/main/java/mcjty/rftools/integration/computers/DialingDeviceDriver.java
+++ b/src/main/java/mcjty/rftools/integration/computers/DialingDeviceDriver.java
@@ -89,7 +89,7 @@ public class DialingDeviceDriver {
                 boolean once = a.checkBoolean(3);
 
                 TileEntity transmitterTE = tile.getWorld().getTileEntity(fromCoordinateMap(transmitterSPos));
-                TileEntity receiverTE = tile.getWorld().getTileEntity(fromCoordinateMap(receiverSPos));
+                TileEntity receiverTE = TeleportationTools.getWorldForDimension(tile.getWorld(), targetDim).getTileEntity(fromCoordinateMap(receiverSPos));
 
                 if (!(transmitterTE instanceof MatterTransmitterTileEntity)) {
                     return new Object[]{null, "Invalid matter transmitter"};


### PR DESCRIPTION
This fixes the OpenComputers Dialing Device driver, allowing it to dial to matter receivers in any dimension other than that of the dialing device.