### PR TITLE
Make #1084 also covers 1.10.2

### DIFF
--- a/src/main/java/mcjty/rftools/items/manual/GuiRFToolsManual.java
+++ b/src/main/java/mcjty/rftools/items/manual/GuiRFToolsManual.java
@@ -11,7 +11,6 @@ import mcjty.lib.gui.widgets.*;
 import mcjty.rftools.RFTools;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
-import net.minecraft.client.resources.Language;
 import net.minecraft.util.ResourceLocation;
 import org.lwjgl.input.Mouse;
 
@@ -42,7 +41,7 @@ public class GuiRFToolsManual extends GuiScreen {
     private static final ResourceLocation iconGuiElements = new ResourceLocation(RFTools.MODID, "textures/gui/guielements.png");
 
     public GuiRFToolsManual(int manual) {
-        String gameLocale = Minecraft.getMinecraft().getLanguageManager().getCurrentLanguage().getLanguageCode();
+        String gameLocale = Minecraft.getMinecraft().getLanguageManager().getCurrentLanguage().getLanguageCode().toLowerCase(java.util.Locale.ENGLISH);
         if (manual == MANUAL_MAIN) {
             if (gameLocale.equals("en_us")) {
                 manualText = manualMainText;


### PR DESCRIPTION
Apparently I forget the fact that RFTools supports 1.10.2 and 1.11.2 at the same time, so here is the very simple fix.