### PR TITLE
Read RF setting for pump builder from config file

### DIFF
--- a/src/main/java/mcjty/rftools/blocks/builder/BuilderConfiguration.java
+++ b/src/main/java/mcjty/rftools/blocks/builder/BuilderConfiguration.java
@@ -67,6 +67,8 @@ public class BuilderConfiguration {
                 "RF per tick that the builder can receive").getInt();
         builderRfPerOperation = cfg.get(CATEGORY_BUILDER, "builderRfPerOperation", builderRfPerOperation,
                 "RF per block operation for the builder when used to build").getInt();
+        builderRfPerLiquid = cfg.get(CATEGORY_BUILDER, "builderRfPerLiquid", builderRfPerLiquid,
+                "Base RF per block operation for the builder when used as a pump").getInt();
         builderRfPerQuarry = cfg.get(CATEGORY_BUILDER, "builderRfPerQuarry", builderRfPerQuarry,
                 "Base RF per block operation for the builder when used as a quarry or voider (actual cost depends on hardness of block)").getInt();
         builderRfPerSkipped = cfg.get(CATEGORY_BUILDER, "builderRfPerSkipped", builderRfPerSkipped,


### PR DESCRIPTION
The builder configuration had a setting for RF per liquid block, but it wasn't actually reading it from the config file.