### PR TITLE
Re-enable OpenComputers integration in RFTools.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,7 @@ dependencies {
     deobfCompile "com.github.mcjty:xnet:1.12-1.3.4"
     deobfCompile "com.github.mcjty:mcjtylib:1.12-2.4.4-SNAPSHOT"
 
-    compile "li.cil.oc:OpenComputers:MC1.10.2-1.6.+:api"
+    compile "li.cil.oc:OpenComputers:MC1.12.1-1.7.+:api"
 }
 
 jar {

--- a/src/main/java/mcjty/rftools/RFTools.java
+++ b/src/main/java/mcjty/rftools/RFTools.java
@@ -170,7 +170,7 @@ public class RFTools implements ModBase {
             FMLInterModComms.sendFunctionMessage("xnet", "getXNet", "mcjty.rftools.xnet.XNetSupport$GetXNet");
         }
 
-        if (Loader.isModLoaded("OpenComputers")) {
+        if (Loader.isModLoaded("opencomputers")) {
             OpenComputersIntegration.init();
         }
     }

--- a/src/main/java/mcjty/rftools/blocks/blockprotector/BlockProtectorTileEntity.java
+++ b/src/main/java/mcjty/rftools/blocks/blockprotector/BlockProtectorTileEntity.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.Set;
 
 //@Optional.InterfaceList({
-//        @Optional.Interface(iface = "li.cil.oc.api.network.SimpleComponent", modid = "OpenComputers"),
+//        @Optional.Interface(iface = "li.cil.oc.api.network.SimpleComponent", modid = "opencomputers"),
 //        @Optional.Interface(iface = "dan200.computercraft.api.peripheral.IPeripheral", modid = "ComputerCraft")})
 public class BlockProtectorTileEntity extends GenericEnergyReceiverTileEntity implements SmartWrenchSelector, ITickable,
         IMachineInformation /*, SimpleComponent, IPeripheral*/ {
@@ -80,19 +80,19 @@ public class BlockProtectorTileEntity extends GenericEnergyReceiverTileEntity im
 //    }
 //
 //    @Override
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public String getComponentName() {
 //        return COMPONENT_NAME;
 //    }
 //
 //    @Callback(doc = "Get the current redstone mode. Values are 'Ignored', 'Off', or 'On'", getter = true)
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] getRedstoneMode(Context context, Arguments args) throws Exception {
 //        return new Object[] { getRedstoneMode().getDescription() };
 //    }
 //
 //    @Callback(doc = "Set the current redstone mode. Values are 'Ignored', 'Off', or 'On'", setter = true)
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] setRedstoneMode(Context context, Arguments args) throws Exception {
 //        String mode = args.checkString(0);
 //        return setRedstoneMode(mode);

--- a/src/main/java/mcjty/rftools/blocks/environmental/EnvironmentalControllerTileEntity.java
+++ b/src/main/java/mcjty/rftools/blocks/environmental/EnvironmentalControllerTileEntity.java
@@ -27,7 +27,7 @@ import javax.annotation.Nullable;
 import java.util.*;
 
 //@Optional.InterfaceList({
-//        @Optional.Interface(iface = "li.cil.oc.api.network.SimpleComponent", modid = "OpenComputers"),
+//        @Optional.Interface(iface = "li.cil.oc.api.network.SimpleComponent", modid = "opencomputers"),
 //        @Optional.Interface(iface = "dan200.computercraft.api.peripheral.IPeripheral", modid = "ComputerCraft")})
 public class EnvironmentalControllerTileEntity extends GenericEnergyReceiverTileEntity implements DefaultSidedInventory, ITickable,
         IMachineInformation /*, SimpleComponent, IPeripheral*/ {
@@ -149,19 +149,19 @@ public class EnvironmentalControllerTileEntity extends GenericEnergyReceiverTile
 //    }
 //
 //    @Override
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public String getComponentName() {
 //        return COMPONENT_NAME;
 //    }
 //
 //    @Callback(doc = "Get the current redstone mode. Values are 'Ignored', 'Off', or 'On'", getter = true)
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] getRedstoneMode(Context context, Arguments args) throws Exception {
 //        return new Object[] { getRedstoneMode().getDescription() };
 //    }
 //
 //    @Callback(doc = "Set the current redstone mode. Values are 'Ignored', 'Off', or 'On'", setter = true)
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] setRedstoneMode(Context context, Arguments args) throws Exception {
 //        String mode = args.checkString(0);
 //        return setRedstoneMode(mode);

--- a/src/main/java/mcjty/rftools/blocks/screens/ScreenControllerTileEntity.java
+++ b/src/main/java/mcjty/rftools/blocks/screens/ScreenControllerTileEntity.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 //@Optional.InterfaceList({
-//        @Optional.Interface(iface = "li.cil.oc.api.network.SimpleComponent", modid = "OpenComputers"),
+//        @Optional.Interface(iface = "li.cil.oc.api.network.SimpleComponent", modid = "opencomputers"),
 //        @Optional.Interface(iface = "dan200.computercraft.api.peripheral.IPeripheral", modid = "ComputerCraft")})
 public class ScreenControllerTileEntity extends GenericEnergyReceiverTileEntity implements ITickable { // implements SimpleComponent, IPeripheral {
 
@@ -74,19 +74,19 @@ public class ScreenControllerTileEntity extends GenericEnergyReceiverTileEntity 
 //    }
 //
 //    @Override
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public String getComponentName() {
 //        return COMPONENT_NAME;
 //    }
 //
 //    @Callback(doc = "Get the amount of screens controlled by this controller", getter = true)
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] getScreenCount(Context context, Arguments args) throws Exception {
 //        return new Object[] { connectedScreens.size() };
 //    }
 //
 //    @Callback(doc = "Get a table with coordinates (every coordinate is a table indexed with 'x', 'y', and 'z') for all connected screens", getter = true)
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] getScreens(Context context, Arguments args) throws Exception {
 //        List<Map<String,Integer>> result = new ArrayList<Map<String, Integer>>();
 //        for (Coordinate screen : connectedScreens) {
@@ -101,7 +101,7 @@ public class ScreenControllerTileEntity extends GenericEnergyReceiverTileEntity 
 //    }
 //
 //    @Callback(doc = "Given a screen coordinate (table indexed by 'x', 'y', and 'z') return the index of that screen", getter = true)
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] getScreenIndex(Context context, Arguments args) throws Exception {
 //        Map screen = args.checkTable(0);
 //        if (!screen.containsKey("x") || !screen.containsKey("y") || !screen.containsKey("z")) {
@@ -124,7 +124,7 @@ public class ScreenControllerTileEntity extends GenericEnergyReceiverTileEntity 
 //    }
 //
 //    @Callback(doc = "Given a screen index return the coordinate (table indexed by 'x', 'y', and 'z') of that screen", getter = true)
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] getScreenCoordinate(Context context, Arguments args) throws Exception {
 //        int index = args.checkInteger(0);
 //        if (index < 0 || index >= connectedScreens.size()) {
@@ -141,7 +141,7 @@ public class ScreenControllerTileEntity extends GenericEnergyReceiverTileEntity 
 //
 //
 //    @Callback(doc = "Add text to all screens listening to the given 'tag'. Parameters are: 'tag', 'text' and 'color' (RGB value)")
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] addText(Context context, Arguments args) throws Exception {
 //        String tag = args.checkString(0);
 //        String text = args.checkString(1);
@@ -151,7 +151,7 @@ public class ScreenControllerTileEntity extends GenericEnergyReceiverTileEntity 
 //    }
 //
 //    @Callback(doc = "Set text to all screens listening to the given 'tag'. Parameters are: 'tag', 'text' and 'color' (RGB value)")
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] setText(Context context, Arguments args) throws Exception {
 //        String tag = args.checkString(0);
 //        String text = args.checkString(1);
@@ -183,7 +183,7 @@ public class ScreenControllerTileEntity extends GenericEnergyReceiverTileEntity 
 //    }
 //
 //    @Callback(doc = "Clear text to all screens listening to the given 'tag'. The 'tag' is the only parameter")
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] clearText(Context context, Arguments args) throws Exception {
 //        String tag = args.checkString(0);
 //
@@ -207,7 +207,7 @@ public class ScreenControllerTileEntity extends GenericEnergyReceiverTileEntity 
 //    }
 //
 //    @Callback(doc = "Get a table of all tags supported by all connected screens", getter = true)
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] getTags(Context context, Arguments args) throws Exception {
 //        List<String> tags = new ArrayList<String>();
 //        for (Coordinate screen : connectedScreens) {

--- a/src/main/java/mcjty/rftools/blocks/shield/ShieldTEBase.java
+++ b/src/main/java/mcjty/rftools/blocks/shield/ShieldTEBase.java
@@ -45,7 +45,7 @@ import javax.annotation.Nullable;
 import java.util.*;
 
 //@Optional.InterfaceList({
-//        @Optional.Interface(iface = "li.cil.oc.api.network.SimpleComponent", modid = "OpenComputers"),
+//        @Optional.Interface(iface = "li.cil.oc.api.network.SimpleComponent", modid = "opencomputers"),
 //        @Optional.Interface(iface = "dan200.computercraft.api.peripheral.IPeripheral", modid = "ComputerCraft")})
 public class ShieldTEBase extends GenericEnergyReceiverTileEntity implements DefaultSidedInventory, SmartWrenchSelector, ITickable,
         IMachineInformation { // @todo }, SimpleComponent, IPeripheral {
@@ -169,20 +169,20 @@ public class ShieldTEBase extends GenericEnergyReceiverTileEntity implements Def
 //    }
 //
 //    @Override
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public String getComponentName() {
 //        return COMPONENT_NAME;
 //    }
 //
 //
 //    @Callback(doc = "Get the current damage mode for the shield. 'Generic' means normal damage while 'Player' means damage like a player would do", getter = true)
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] getDamageMode(Context context, Arguments args) throws Exception {
 //        return new Object[] { getDamageMode().getDescription() };
 //    }
 //
 //    @Callback(doc = "Set the current damage mode for the shield. 'Generic' means normal damage while 'Player' means damage like a player would do", setter = true)
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] setDamageMode(Context context, Arguments args) throws Exception {
 //        String mode = args.checkString(0);
 //        return setDamageMode(mode);
@@ -198,13 +198,13 @@ public class ShieldTEBase extends GenericEnergyReceiverTileEntity implements Def
     }
 
 //    @Callback(doc = "Get the current redstone mode. Values are 'Ignored', 'Off', or 'On'", getter = true)
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] getRedstoneMode(Context context, Arguments args) throws Exception {
 //        return new Object[] { getRedstoneMode().getDescription() };
 //    }
 //
 //    @Callback(doc = "Set the current redstone mode. Values are 'Ignored', 'Off', or 'On'", setter = true)
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] setRedstoneMode(Context context, Arguments args) throws Exception {
 //        String mode = args.checkString(0);
 //        return setRedstoneMode(mode);
@@ -221,13 +221,13 @@ public class ShieldTEBase extends GenericEnergyReceiverTileEntity implements Def
 
 
 //    @Callback(doc = "Get the current shield rendering mode. Values are 'Invisible', 'Shield', or 'Solid'", getter = true)
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] getShieldRenderingMode(Context context, Arguments args) throws Exception {
 //        return new Object[] { getShieldRenderingMode().getDescription() };
 //    }
 //
 //    @Callback(doc = "Set the current shield rendering mode. Values are 'Invisible', 'Shield', or 'Solid'", setter = true)
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] setShieldRenderingMode(Context context, Arguments args) throws Exception {
 //        String mode = args.checkString(0);
 //        return setShieldRenderingMode(mode);
@@ -243,25 +243,25 @@ public class ShieldTEBase extends GenericEnergyReceiverTileEntity implements Def
     }
 
 //    @Callback(doc = "Return true if the shield is active", getter = true)
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] isShieldActive(Context context, Arguments args) throws Exception {
 //        return new Object[] { isShieldActive() };
 //    }
 //
 //    @Callback(doc = "Return true if the shield is composed (i.e. formed)", getter = true)
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] isShieldComposed(Context context, Arguments args) throws Exception {
 //        return new Object[] { isShieldComposed() };
 //    }
 //
 //    @Callback(doc = "Form the shield (compose it)")
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] composeShield(Context context, Arguments args) throws Exception {
 //        return composeShieldComp(false);
 //    }
 //
 //    @Callback(doc = "Form the shield (compose it). This version works in disconnected mode (template blocks will connect on corners too)")
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] composeShieldDsc(Context context, Arguments args) throws Exception {
 //        return composeShieldComp(true);
 //    }
@@ -276,7 +276,7 @@ public class ShieldTEBase extends GenericEnergyReceiverTileEntity implements Def
     }
 
 //    @Callback(doc = "Break down the shield (decompose it)")
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] decomposeShield(Context context, Arguments args) throws Exception {
 //        return decomposeShieldComp();
 //    }

--- a/src/main/java/mcjty/rftools/integration/computers/CoalGeneratorDriver.java
+++ b/src/main/java/mcjty/rftools/integration/computers/CoalGeneratorDriver.java
@@ -3,7 +3,7 @@ package mcjty.rftools.integration.computers;
 import li.cil.oc.api.machine.Arguments;
 import li.cil.oc.api.machine.Callback;
 import li.cil.oc.api.machine.Context;
-import li.cil.oc.api.prefab.ManagedEnvironment;
+import li.cil.oc.api.prefab.AbstractManagedEnvironment;
 import mcjty.lib.integration.computers.AbstractOCDriver;
 import mcjty.lib.varia.RedstoneMode;
 import mcjty.rftools.blocks.generator.CoalGeneratorTileEntity;
@@ -73,7 +73,7 @@ public class CoalGeneratorDriver {
         }
 
         @Override
-        public ManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side, TileEntity tile) {
+        public AbstractManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side, TileEntity tile) {
             return new InternalManagedEnvironment((CoalGeneratorTileEntity) tile);
         }
     }

--- a/src/main/java/mcjty/rftools/integration/computers/DialingDeviceDriver.java
+++ b/src/main/java/mcjty/rftools/integration/computers/DialingDeviceDriver.java
@@ -3,7 +3,7 @@ package mcjty.rftools.integration.computers;
 import li.cil.oc.api.machine.Arguments;
 import li.cil.oc.api.machine.Callback;
 import li.cil.oc.api.machine.Context;
-import li.cil.oc.api.prefab.ManagedEnvironment;
+import li.cil.oc.api.prefab.AbstractManagedEnvironment;
 import mcjty.lib.integration.computers.AbstractOCDriver;
 import mcjty.rftools.blocks.teleporter.*;
 import net.minecraft.tileentity.TileEntity;
@@ -159,7 +159,7 @@ public class DialingDeviceDriver {
         }
 
         @Override
-        public ManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side, TileEntity tile) {
+        public AbstractManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side, TileEntity tile) {
             return new InternalManagedEnvironment((DialingDeviceTileEntity) tile);
         }
     }

--- a/src/main/java/mcjty/rftools/integration/computers/EndergenicDriver.java
+++ b/src/main/java/mcjty/rftools/integration/computers/EndergenicDriver.java
@@ -3,7 +3,7 @@ package mcjty.rftools.integration.computers;
 import li.cil.oc.api.machine.Arguments;
 import li.cil.oc.api.machine.Callback;
 import li.cil.oc.api.machine.Context;
-import li.cil.oc.api.prefab.ManagedEnvironment;
+import li.cil.oc.api.prefab.AbstractManagedEnvironment;
 import mcjty.lib.integration.computers.AbstractOCDriver;
 import mcjty.rftools.blocks.endergen.EndergenicTileEntity;
 import net.minecraft.tileentity.TileEntity;
@@ -126,7 +126,7 @@ public class EndergenicDriver {
         }
 
         @Override
-        public ManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side, TileEntity tile) {
+        public AbstractManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side, TileEntity tile) {
             return new InternalManagedEnvironment((EndergenicTileEntity) tile);
         }
     }

--- a/src/main/java/mcjty/rftools/integration/computers/LiquidMonitorDriver.java
+++ b/src/main/java/mcjty/rftools/integration/computers/LiquidMonitorDriver.java
@@ -3,7 +3,7 @@ package mcjty.rftools.integration.computers;
 import li.cil.oc.api.machine.Arguments;
 import li.cil.oc.api.machine.Callback;
 import li.cil.oc.api.machine.Context;
-import li.cil.oc.api.prefab.ManagedEnvironment;
+import li.cil.oc.api.prefab.AbstractManagedEnvironment;
 import mcjty.lib.integration.computers.AbstractOCDriver;
 import mcjty.rftools.blocks.monitor.LiquidMonitorBlockTileEntity;
 import mcjty.rftools.blocks.monitor.RFMonitorMode;
@@ -112,7 +112,7 @@ public class LiquidMonitorDriver {
         }
 
         @Override
-        public ManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side, TileEntity tile) {
+        public AbstractManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side, TileEntity tile) {
             return new InternalManagedEnvironment((LiquidMonitorBlockTileEntity) tile);
         }
     }

--- a/src/main/java/mcjty/rftools/integration/computers/MachineInfuserDriver.java
+++ b/src/main/java/mcjty/rftools/integration/computers/MachineInfuserDriver.java
@@ -3,7 +3,7 @@ package mcjty.rftools.integration.computers;
 import li.cil.oc.api.machine.Arguments;
 import li.cil.oc.api.machine.Callback;
 import li.cil.oc.api.machine.Context;
-import li.cil.oc.api.prefab.ManagedEnvironment;
+import li.cil.oc.api.prefab.AbstractManagedEnvironment;
 import mcjty.lib.base.GeneralConfig;
 import mcjty.lib.integration.computers.AbstractOCDriver;
 import mcjty.rftools.blocks.infuser.MachineInfuserTileEntity;
@@ -57,7 +57,7 @@ public class MachineInfuserDriver {
         }
 
         @Override
-        public ManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side, TileEntity tile) {
+        public AbstractManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side, TileEntity tile) {
             return new InternalManagedEnvironment((MachineInfuserTileEntity) tile);
         }
     }

--- a/src/main/java/mcjty/rftools/integration/computers/MatterReceiverDriver.java
+++ b/src/main/java/mcjty/rftools/integration/computers/MatterReceiverDriver.java
@@ -3,7 +3,7 @@ package mcjty.rftools.integration.computers;
 import li.cil.oc.api.machine.Arguments;
 import li.cil.oc.api.machine.Callback;
 import li.cil.oc.api.machine.Context;
-import li.cil.oc.api.prefab.ManagedEnvironment;
+import li.cil.oc.api.prefab.AbstractManagedEnvironment;
 import mcjty.lib.integration.computers.AbstractOCDriver;
 import mcjty.rftools.blocks.teleporter.MatterReceiverTileEntity;
 import net.minecraft.tileentity.TileEntity;
@@ -52,7 +52,7 @@ public class MatterReceiverDriver {
         }
 
         @Override
-        public ManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side, TileEntity tile) {
+        public AbstractManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side, TileEntity tile) {
             return new InternalManagedEnvironment((MatterReceiverTileEntity) tile);
         }
     }

--- a/src/main/java/mcjty/rftools/integration/computers/MatterTransmitterDriver.java
+++ b/src/main/java/mcjty/rftools/integration/computers/MatterTransmitterDriver.java
@@ -3,7 +3,7 @@ package mcjty.rftools.integration.computers;
 import li.cil.oc.api.machine.Arguments;
 import li.cil.oc.api.machine.Callback;
 import li.cil.oc.api.machine.Context;
-import li.cil.oc.api.prefab.ManagedEnvironment;
+import li.cil.oc.api.prefab.AbstractManagedEnvironment;
 import mcjty.lib.integration.computers.AbstractOCDriver;
 import mcjty.rftools.blocks.teleporter.MatterTransmitterTileEntity;
 import net.minecraft.tileentity.TileEntity;
@@ -68,7 +68,7 @@ public class MatterTransmitterDriver {
         }
 
         @Override
-        public ManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side, TileEntity tile) {
+        public AbstractManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side, TileEntity tile) {
             return new InternalManagedEnvironment((MatterTransmitterTileEntity) tile);
         }
     }

--- a/src/main/java/mcjty/rftools/integration/computers/OpenComputersIntegration.java
+++ b/src/main/java/mcjty/rftools/integration/computers/OpenComputersIntegration.java
@@ -4,7 +4,7 @@ import li.cil.oc.api.Driver;
 import net.minecraftforge.fml.common.Optional;
 
 public class OpenComputersIntegration {
-    @Optional.Method(modid="OpenComputers")
+    @Optional.Method(modid="opencomputers")
     public static void init() {
         Driver.add(new MachineInfuserDriver.OCDriver());
         Driver.add(new DialingDeviceDriver.OCDriver());

--- a/src/main/java/mcjty/rftools/integration/computers/PearlInjectorDriver.java
+++ b/src/main/java/mcjty/rftools/integration/computers/PearlInjectorDriver.java
@@ -3,7 +3,7 @@ package mcjty.rftools.integration.computers;
 import li.cil.oc.api.machine.Arguments;
 import li.cil.oc.api.machine.Callback;
 import li.cil.oc.api.machine.Context;
-import li.cil.oc.api.prefab.ManagedEnvironment;
+import li.cil.oc.api.prefab.AbstractManagedEnvironment;
 import mcjty.lib.container.InventoryHelper;
 import mcjty.lib.integration.computers.AbstractOCDriver;
 import mcjty.rftools.blocks.endergen.PearlInjectorTileEntity;
@@ -52,7 +52,7 @@ public class PearlInjectorDriver {
         }
 
         @Override
-        public ManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side, TileEntity tile) {
+        public AbstractManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side, TileEntity tile) {
             return new InternalManagedEnvironment((PearlInjectorTileEntity) tile);
         }
     }

--- a/src/main/java/mcjty/rftools/integration/computers/PowercellDriver.java
+++ b/src/main/java/mcjty/rftools/integration/computers/PowercellDriver.java
@@ -3,7 +3,7 @@ package mcjty.rftools.integration.computers;
 import li.cil.oc.api.machine.Arguments;
 import li.cil.oc.api.machine.Callback;
 import li.cil.oc.api.machine.Context;
-import li.cil.oc.api.prefab.ManagedEnvironment;
+import li.cil.oc.api.prefab.AbstractManagedEnvironment;
 import mcjty.lib.integration.computers.AbstractOCDriver;
 import mcjty.rftools.blocks.powercell.PowerCellTileEntity;
 import net.minecraft.tileentity.TileEntity;
@@ -62,7 +62,7 @@ public class PowercellDriver {
         }
 
         @Override
-        public ManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side, TileEntity tile) {
+        public AbstractManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side, TileEntity tile) {
             return new InternalManagedEnvironment((PowerCellTileEntity) tile);
         }
     }

--- a/src/main/java/mcjty/rftools/integration/computers/RFMonitorDriver.java
+++ b/src/main/java/mcjty/rftools/integration/computers/RFMonitorDriver.java
@@ -3,7 +3,7 @@ package mcjty.rftools.integration.computers;
 import li.cil.oc.api.machine.Arguments;
 import li.cil.oc.api.machine.Callback;
 import li.cil.oc.api.machine.Context;
-import li.cil.oc.api.prefab.ManagedEnvironment;
+import li.cil.oc.api.prefab.AbstractManagedEnvironment;
 import mcjty.lib.integration.computers.AbstractOCDriver;
 import mcjty.lib.varia.EnergyTools;
 import mcjty.rftools.blocks.monitor.RFMonitorBlockTileEntity;
@@ -100,7 +100,7 @@ public class RFMonitorDriver {
         }
 
         @Override
-        public ManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side, TileEntity tile) {
+        public AbstractManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side, TileEntity tile) {
             return new InternalManagedEnvironment((RFMonitorBlockTileEntity) tile);
         }
     }


### PR DESCRIPTION
OC integration was broken for two reasons:

1. There's been a small change in the OC API, which also needed a fix in
McJtyLib (see McJty/McJtyLib#41). The ManagedEnvironment class was
renamed to AbstractManagedEnvironment.

2. Forge mod loading forces lowercase mod IDs since sometime around
1.11, so "OpenComputers" is now "opencomputers".