### PR TITLE
Use lowercase OpenComputers mod ID

### DIFF
--- a/src/main/java/mcjty/rftools/RFTools.java
+++ b/src/main/java/mcjty/rftools/RFTools.java
@@ -181,7 +181,7 @@ public class RFTools implements ModBase {
             FMLInterModComms.sendFunctionMessage("xnet", "getXNet", "mcjty.rftools.xnet.XNetSupport$GetXNet");
         }
 
-        if (Loader.isModLoaded("OpenComputers")) {
+        if (Loader.isModLoaded("opencomputers") || Loader.isModLoaded("OpenComputers")) {
             OpenComputersIntegration.init();
         }
     }

--- a/src/main/java/mcjty/rftools/blocks/blockprotector/BlockProtectorTileEntity.java
+++ b/src/main/java/mcjty/rftools/blocks/blockprotector/BlockProtectorTileEntity.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.Set;
 
 //@Optional.InterfaceList({
-//        @Optional.Interface(iface = "li.cil.oc.api.network.SimpleComponent", modid = "OpenComputers"),
+//        @Optional.Interface(iface = "li.cil.oc.api.network.SimpleComponent", modid = "opencomputers"),
 //        @Optional.Interface(iface = "dan200.computercraft.api.peripheral.IPeripheral", modid = "ComputerCraft")})
 public class BlockProtectorTileEntity extends GenericEnergyReceiverTileEntity implements SmartWrenchSelector, ITickable,
         IMachineInformation /*, SimpleComponent, IPeripheral*/ {
@@ -81,19 +81,19 @@ public class BlockProtectorTileEntity extends GenericEnergyReceiverTileEntity im
 //    }
 //
 //    @Override
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public String getComponentName() {
 //        return COMPONENT_NAME;
 //    }
 //
 //    @Callback(doc = "Get the current redstone mode. Values are 'Ignored', 'Off', or 'On'", getter = true)
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] getRedstoneMode(Context context, Arguments args) throws Exception {
 //        return new Object[] { getRedstoneMode().getDescription() };
 //    }
 //
 //    @Callback(doc = "Set the current redstone mode. Values are 'Ignored', 'Off', or 'On'", setter = true)
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] setRedstoneMode(Context context, Arguments args) throws Exception {
 //        String mode = args.checkString(0);
 //        return setRedstoneMode(mode);

--- a/src/main/java/mcjty/rftools/blocks/environmental/EnvironmentalControllerTileEntity.java
+++ b/src/main/java/mcjty/rftools/blocks/environmental/EnvironmentalControllerTileEntity.java
@@ -28,7 +28,7 @@ import javax.annotation.Nullable;
 import java.util.*;
 
 //@Optional.InterfaceList({
-//        @Optional.Interface(iface = "li.cil.oc.api.network.SimpleComponent", modid = "OpenComputers"),
+//        @Optional.Interface(iface = "li.cil.oc.api.network.SimpleComponent", modid = "opencomputers"),
 //        @Optional.Interface(iface = "dan200.computercraft.api.peripheral.IPeripheral", modid = "ComputerCraft")})
 public class EnvironmentalControllerTileEntity extends GenericEnergyReceiverTileEntity implements DefaultSidedInventory, ITickable,
         IMachineInformation /*, SimpleComponent, IPeripheral*/ {
@@ -151,19 +151,19 @@ public class EnvironmentalControllerTileEntity extends GenericEnergyReceiverTile
 //    }
 //
 //    @Override
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public String getComponentName() {
 //        return COMPONENT_NAME;
 //    }
 //
 //    @Callback(doc = "Get the current redstone mode. Values are 'Ignored', 'Off', or 'On'", getter = true)
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] getRedstoneMode(Context context, Arguments args) throws Exception {
 //        return new Object[] { getRedstoneMode().getDescription() };
 //    }
 //
 //    @Callback(doc = "Set the current redstone mode. Values are 'Ignored', 'Off', or 'On'", setter = true)
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] setRedstoneMode(Context context, Arguments args) throws Exception {
 //        String mode = args.checkString(0);
 //        return setRedstoneMode(mode);

--- a/src/main/java/mcjty/rftools/blocks/shield/ShieldTEBase.java
+++ b/src/main/java/mcjty/rftools/blocks/shield/ShieldTEBase.java
@@ -46,7 +46,7 @@ import javax.annotation.Nullable;
 import java.util.*;
 
 //@Optional.InterfaceList({
-//        @Optional.Interface(iface = "li.cil.oc.api.network.SimpleComponent", modid = "OpenComputers"),
+//        @Optional.Interface(iface = "li.cil.oc.api.network.SimpleComponent", modid = "opencomputers"),
 //        @Optional.Interface(iface = "dan200.computercraft.api.peripheral.IPeripheral", modid = "ComputerCraft")})
 public class ShieldTEBase extends GenericEnergyReceiverTileEntity implements DefaultSidedInventory, SmartWrenchSelector, ITickable,
         IMachineInformation { // @todo }, SimpleComponent, IPeripheral {
@@ -171,20 +171,20 @@ public class ShieldTEBase extends GenericEnergyReceiverTileEntity implements Def
 //    }
 //
 //    @Override
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public String getComponentName() {
 //        return COMPONENT_NAME;
 //    }
 //
 //
 //    @Callback(doc = "Get the current damage mode for the shield. 'Generic' means normal damage while 'Player' means damage like a player would do", getter = true)
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] getDamageMode(Context context, Arguments args) throws Exception {
 //        return new Object[] { getDamageMode().getDescription() };
 //    }
 //
 //    @Callback(doc = "Set the current damage mode for the shield. 'Generic' means normal damage while 'Player' means damage like a player would do", setter = true)
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] setDamageMode(Context context, Arguments args) throws Exception {
 //        String mode = args.checkString(0);
 //        return setDamageMode(mode);
@@ -200,13 +200,13 @@ public class ShieldTEBase extends GenericEnergyReceiverTileEntity implements Def
     }
 
 //    @Callback(doc = "Get the current redstone mode. Values are 'Ignored', 'Off', or 'On'", getter = true)
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] getRedstoneMode(Context context, Arguments args) throws Exception {
 //        return new Object[] { getRedstoneMode().getDescription() };
 //    }
 //
 //    @Callback(doc = "Set the current redstone mode. Values are 'Ignored', 'Off', or 'On'", setter = true)
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] setRedstoneMode(Context context, Arguments args) throws Exception {
 //        String mode = args.checkString(0);
 //        return setRedstoneMode(mode);
@@ -223,13 +223,13 @@ public class ShieldTEBase extends GenericEnergyReceiverTileEntity implements Def
 
 
 //    @Callback(doc = "Get the current shield rendering mode. Values are 'Invisible', 'Shield', or 'Solid'", getter = true)
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] getShieldRenderingMode(Context context, Arguments args) throws Exception {
 //        return new Object[] { getShieldRenderingMode().getDescription() };
 //    }
 //
 //    @Callback(doc = "Set the current shield rendering mode. Values are 'Invisible', 'Shield', or 'Solid'", setter = true)
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] setShieldRenderingMode(Context context, Arguments args) throws Exception {
 //        String mode = args.checkString(0);
 //        return setShieldRenderingMode(mode);
@@ -245,25 +245,25 @@ public class ShieldTEBase extends GenericEnergyReceiverTileEntity implements Def
     }
 
 //    @Callback(doc = "Return true if the shield is active", getter = true)
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] isShieldActive(Context context, Arguments args) throws Exception {
 //        return new Object[] { isShieldActive() };
 //    }
 //
 //    @Callback(doc = "Return true if the shield is composed (i.e. formed)", getter = true)
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] isShieldComposed(Context context, Arguments args) throws Exception {
 //        return new Object[] { isShieldComposed() };
 //    }
 //
 //    @Callback(doc = "Form the shield (compose it)")
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] composeShield(Context context, Arguments args) throws Exception {
 //        return composeShieldComp(false);
 //    }
 //
 //    @Callback(doc = "Form the shield (compose it). This version works in disconnected mode (template blocks will connect on corners too)")
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] composeShieldDsc(Context context, Arguments args) throws Exception {
 //        return composeShieldComp(true);
 //    }
@@ -278,7 +278,7 @@ public class ShieldTEBase extends GenericEnergyReceiverTileEntity implements Def
     }
 
 //    @Callback(doc = "Break down the shield (decompose it)")
-//    @Optional.Method(modid = "OpenComputers")
+//    @Optional.Method(modid = "opencomputers")
 //    public Object[] decomposeShield(Context context, Arguments args) throws Exception {
 //        return decomposeShieldComp();
 //    }

--- a/src/main/java/mcjty/rftools/integration/computers/OpenComputersIntegration.java
+++ b/src/main/java/mcjty/rftools/integration/computers/OpenComputersIntegration.java
@@ -4,7 +4,7 @@ import li.cil.oc.api.Driver;
 import net.minecraftforge.fml.common.Optional;
 
 public class OpenComputersIntegration {
-    @Optional.Method(modid="OpenComputers")
+    @Optional.Method(modid="opencomputers")
     public static void init() {
         Driver.add(new MachineInfuserDriver.OCDriver());
         Driver.add(new DialingDeviceDriver.OCDriver());


### PR DESCRIPTION
OC for 1.10 just got a change that makes @Optional annotations work even with
lowercase mod IDs, so that we can do things that work in both 1.10 and 1.11.
Do our side of that now (including in places we need to reimplement still).