### PR TITLE
Call setHasSubtypes(true) on dimensional shard ore

### DIFF
--- a/src/main/java/mcjty/rftools/blocks/ores/DimensionalShardItemBlock.java
+++ b/src/main/java/mcjty/rftools/blocks/ores/DimensionalShardItemBlock.java
@@ -6,6 +6,7 @@ import net.minecraft.item.ItemBlock;
 public class DimensionalShardItemBlock extends ItemBlock {
     public DimensionalShardItemBlock(Block block) {
         super(block);
+        setHasSubtypes(true);
     }
 
     @Override


### PR DESCRIPTION
This fixes the nether and end variants of dimensional shard ore dropping as
the overworld variant when silk touched.