### PR TITLE
Remove override of canEntityDestroy

### DIFF
--- a/src/main/java/mcjty/rftools/blocks/GenericRFToolsBlock.java
+++ b/src/main/java/mcjty/rftools/blocks/GenericRFToolsBlock.java
@@ -3,27 +3,18 @@ package mcjty.rftools.blocks;
 import mcjty.lib.container.GenericBlock;
 import mcjty.lib.container.GenericItemBlock;
 import mcjty.lib.entity.GenericTileEntity;
-import mcjty.lib.varia.GlobalCoordinate;
 import mcjty.lib.varia.Logging;
 import mcjty.rftools.RFTools;
-import mcjty.rftools.blocks.blockprotector.BlockProtectorConfiguration;
-import mcjty.rftools.blocks.blockprotector.BlockProtectors;
 import mcjty.rftools.blocks.security.OrphaningCardItem;
 import mcjty.rftools.blocks.security.SecurityChannels;
 import mcjty.rftools.blocks.security.SecurityConfiguration;
 import net.minecraft.block.material.Material;
-import net.minecraft.block.state.IBlockState;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextFormatting;
-import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
-
-import java.util.Collection;
 
 public abstract class GenericRFToolsBlock<T extends GenericTileEntity, C extends Container> extends GenericBlock<T, C> {
 
@@ -42,18 +33,6 @@ public abstract class GenericRFToolsBlock<T extends GenericTileEntity, C extends
                                String name, boolean isContainer) {
         super(RFTools.instance, material, tileEntityClass, containerClass, itemBlockClass, name, isContainer);
         setCreativeTab(RFTools.tabRfTools);
-    }
-
-    @Override
-    public boolean canEntityDestroy(IBlockState state, IBlockAccess world, BlockPos pos, Entity entity) {
-        boolean b = super.canEntityDestroy(state, world, pos, entity);
-        if (b && BlockProtectorConfiguration.enabled) {
-            Collection<GlobalCoordinate> protectors = BlockProtectors.getProtectors(entity.getEntityWorld(), pos.getX(), pos.getY(), pos.getZ());
-            if (BlockProtectors.checkHarvestProtection(pos.getX(), pos.getY(), pos.getZ(), world, protectors)) {
-                return false;
-            }
-        }
-        return b;
     }
 
     @Override


### PR DESCRIPTION
Everything that calls canEntityDestroy also fires one of the events that the
block protector already hooks, and there's no reason that we need to have a
redundant layer of protection on our own blocks.