### PR TITLE
Move PacketGetPlayers and PacketPlayersReady to .network

### DIFF
--- a/src/main/java/mcjty/rftools/blocks/environmental/GuiEnvironmentalController.java
+++ b/src/main/java/mcjty/rftools/blocks/environmental/GuiEnvironmentalController.java
@@ -16,7 +16,7 @@ import mcjty.lib.gui.widgets.TextField;
 import mcjty.lib.network.Argument;
 import mcjty.lib.varia.RedstoneMode;
 import mcjty.rftools.RFTools;
-import mcjty.rftools.blocks.teleporter.PacketGetPlayers;
+import mcjty.rftools.network.PacketGetPlayers;
 import mcjty.rftools.network.RFToolsMessages;
 import net.minecraft.util.ResourceLocation;
 import org.lwjgl.input.Keyboard;

--- a/src/main/java/mcjty/rftools/blocks/teleporter/GuiMatterReceiver.java
+++ b/src/main/java/mcjty/rftools/blocks/teleporter/GuiMatterReceiver.java
@@ -15,6 +15,7 @@ import mcjty.lib.gui.widgets.Panel;
 import mcjty.lib.gui.widgets.TextField;
 import mcjty.lib.network.Argument;
 import mcjty.rftools.RFTools;
+import mcjty.rftools.network.PacketGetPlayers;
 import mcjty.rftools.network.RFToolsMessages;
 import org.lwjgl.input.Keyboard;
 

--- a/src/main/java/mcjty/rftools/blocks/teleporter/GuiMatterTransmitter.java
+++ b/src/main/java/mcjty/rftools/blocks/teleporter/GuiMatterTransmitter.java
@@ -15,6 +15,7 @@ import mcjty.lib.gui.widgets.Panel;
 import mcjty.lib.gui.widgets.TextField;
 import mcjty.lib.network.Argument;
 import mcjty.rftools.RFTools;
+import mcjty.rftools.network.PacketGetPlayers;
 import mcjty.rftools.network.RFToolsMessages;
 import org.lwjgl.input.Keyboard;
 

--- a/src/main/java/mcjty/rftools/network/PacketGetPlayers.java
+++ b/src/main/java/mcjty/rftools/network/PacketGetPlayers.java
@@ -1,4 +1,4 @@
-package mcjty.rftools.blocks.teleporter;
+package mcjty.rftools.network;
 
 import io.netty.buffer.ByteBuf;
 import mcjty.lib.network.CommandHandler;
@@ -6,7 +6,6 @@ import mcjty.lib.network.NetworkTools;
 import mcjty.lib.network.PacketRequestListFromServer;
 import mcjty.lib.varia.Logging;
 import mcjty.rftools.RFTools;
-import mcjty.rftools.network.RFToolsMessages;
 import mcjty.typed.Type;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;

--- a/src/main/java/mcjty/rftools/network/PacketPlayersReady.java
+++ b/src/main/java/mcjty/rftools/network/PacketPlayersReady.java
@@ -1,4 +1,4 @@
-package mcjty.rftools.blocks.teleporter;
+package mcjty.rftools.network;
 
 import io.netty.buffer.ByteBuf;
 import mcjty.lib.network.ClientCommandHandler;


### PR DESCRIPTION
These are used by the environmental controller too, so they shouldn't live
in the .blocks.teleporter package.