### PR TITLE
Allow proper collision on non-rectangular shaped elevators.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bin/
 .idea/
 build/
 run/
+/.nb-gradle/

--- a/src/main/java/mcjty/rftools/blocks/elevator/ElevatorTESR.java
+++ b/src/main/java/mcjty/rftools/blocks/elevator/ElevatorTESR.java
@@ -12,7 +12,6 @@ import net.minecraft.crash.CrashReportCategory;
 import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.EnumBlockRenderType;
 import net.minecraft.util.ReportedException;
-import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.WorldType;
@@ -31,8 +30,7 @@ public class ElevatorTESR extends TileEntitySpecialRenderer<ElevatorTileEntity> 
 
         if (te.isMoving()) {
             // Correction in the y translation to avoid jitter when both player and platform are moving
-            AxisAlignedBB aabb = te.getAABBAboveElevator(0);
-            boolean on = Minecraft.getMinecraft().player.getEntityBoundingBox().intersects(aabb);
+            boolean on = te.intersects(Minecraft.getMinecraft().player.getEntityBoundingBox());
 
             double diff = on ? (te.getPos().getY() - (y+te.getMovingY()) - 1) : 0;
 


### PR DESCRIPTION
This change breaks the bounding box into strips rather than a single bounding box.  This gives a more expected behaviour to non-rectangular platforms.  Due to the "big margin" check sometimes it is difficult to fall through a one block gap, perhaps it is worth making the margin a config value (how was the value 150 chosen anyway?).

Two notes:
1) I am not sure how one would "upgrade" existing elevators which were moving on world load.  One method could be a hack like:
```
if (tagCompound.hasKey("bminX")) {
    bounds.clear();
    int bminX = tagCompound.getInteger("bminX");
    int bminZ = tagCompound.getInteger("bminZ");
    int bmaxX = tagCompound.getInteger("bmaxX");
    int bmaxZ = tagCompound.getInteger("bmaxZ");
    bounds.add(new Bounds(bminX, bminZ, bmaxX, bmaxZ));
}
```

2) I have never really done any code in java let alone a minecraft mod, so this approach may not be implemented optimally, this approach was done more or less by vaguely emulating the style of surrounding code where obvious.  I am open to changing or correcting the implementation if there is a better way to do it.