### PR TITLE
Make tick order predictable for endergenic setups

### DIFF
--- a/src/main/java/mcjty/rftools/ForgeEventHandlers.java
+++ b/src/main/java/mcjty/rftools/ForgeEventHandlers.java
@@ -9,7 +9,6 @@ import mcjty.lib.varia.WrenchChecker;
 import mcjty.rftools.blocks.ModBlocks;
 import mcjty.rftools.blocks.blockprotector.BlockProtectorConfiguration;
 import mcjty.rftools.blocks.blockprotector.BlockProtectors;
-import mcjty.rftools.blocks.endergen.EndergenicTileEntity;
 import mcjty.rftools.blocks.environmental.NoTeleportAreaManager;
 import mcjty.rftools.blocks.environmental.PeacefulAreaManager;
 import mcjty.rftools.blocks.screens.ScreenBlock;
@@ -295,11 +294,7 @@ public class ForgeEventHandlers {
     @SubscribeEvent
     public void onPostWorldTick(TickEvent.WorldTickEvent event) {
         if (!event.world.isRemote) {
-            for (EndergenicTileEntity endergenic : EndergenicTileEntity.todoEndergenics) {
-                endergenic.checkStateServer();
-            }
-            EndergenicTileEntity.todoEndergenics.clear();
-            EndergenicTileEntity.endergenicsAdded.clear();
+            TickOrderHandler.postWorldTick();
         }
     }
 

--- a/src/main/java/mcjty/rftools/TickOrderHandler.java
+++ b/src/main/java/mcjty/rftools/TickOrderHandler.java
@@ -1,0 +1,101 @@
+package mcjty.rftools;
+
+import mcjty.rftools.blocks.endergen.EnderMonitorTileEntity;
+import mcjty.rftools.blocks.endergen.EndergenicTileEntity;
+import mcjty.rftools.blocks.endergen.PearlInjectorTileEntity;
+import mcjty.rftools.blocks.logic.sequencer.SequencerTileEntity;
+import mcjty.rftools.blocks.logic.timer.TimerTileEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TickOrderHandler {
+    public interface ICheckStateServer {
+        void checkStateServer();
+    }
+
+    private static List<PearlInjectorTileEntity> pearlInjectors = new ArrayList<>();
+
+    private static List<EndergenicTileEntity> connectedEndergenics = new ArrayList<>();
+    private static List<EndergenicTileEntity> endergenics = new ArrayList<>();
+
+    private static List<SequencerTileEntity> sequencers = new ArrayList<>();
+    private static List<TimerTileEntity> timers = new ArrayList<>();
+    private static List<EnderMonitorTileEntity> enderMonitors = new ArrayList<>();
+
+    private TickOrderHandler() {
+    }
+
+    public static void queuePearlInjector(PearlInjectorTileEntity pearlInjector) {
+        pearlInjectors.add(pearlInjector);
+
+        // Find all connected endergenics in order
+        EndergenicTileEntity endergenic = pearlInjector.findEndergenicTileEntity();
+        while (endergenic != null && !connectedEndergenics.contains(endergenic)) {
+            connectedEndergenics.add(endergenic);
+            endergenic = endergenic.getDestinationTE();
+        }
+
+    }
+
+    public static void queueEndergenic(EndergenicTileEntity endergenic) {
+        endergenics.add(endergenic);
+    }
+
+    public static void queueSequencer(SequencerTileEntity sequencer) {
+        sequencers.add(sequencer);
+    }
+
+    public static void queueTimer(TimerTileEntity timer) {
+        timers.add(timer);
+    }
+
+    public static void queueEnderMonitor(EnderMonitorTileEntity enderMonitor) {
+        enderMonitors.add(enderMonitor);
+    }
+
+    private static <T extends ICheckStateServer> void checkStateServer(List<T> tileEntities) {
+        for (ICheckStateServer tileEntity : tileEntities) {
+            tileEntity.checkStateServer();
+        }
+        tileEntities.clear();
+    }
+
+    static void postWorldTick() {
+        /*
+            There is *no* pearl delay between:
+            * Pearl Injector -> Endergenic (connected)
+            * Endergenic -> Endergenic (connected) *except* for last one to first one (one tick)
+
+            It is possible to have a consistent pearl delay of one tick by reversing the tick order of the
+            endergenics, however this slows down the cycle a lot.
+
+            At this point everything else has ticked already, including redstone. If a redstone source entity is now
+            ticked *before* its destination entity the delay depends on if there is a direct connection or a redstone
+            connection between the blocks. If an redstone source entity is ticked *before* its destination entity the
+            delay is always exactly one tick. The tick order was chosen in order for the most common and useful
+            combinations to have consistent delay, i.e. one tick.
+
+            There is exactly *one tick* delay between both w/ and w/o redstone between:
+            * Ender Monitor -> Pearl Injector, Endergenic, Sequencer, Timer
+            * Timer -> Pearl Injector, Endergenic, Sequencer
+            * Sequencer -> Pearl Injector, Endergenic
+
+            There is *no* delay w/o redstone and *one tick* delay w/ redstone between:
+            * Sequencer -> Timer
+
+            There is *no* delay or *one tick* delay (placement/load order/redstone dependent) between:
+            * Sequencer -> Sequencer
+            * Timer -> Timer
+         */
+        checkStateServer(pearlInjectors);
+
+        endergenics.removeAll(connectedEndergenics);
+        checkStateServer(connectedEndergenics); // In order of connection
+        checkStateServer(endergenics); // Unconnected
+
+        checkStateServer(sequencers);
+        checkStateServer(timers);
+        checkStateServer(enderMonitors);
+    }
+}

--- a/src/main/java/mcjty/rftools/blocks/endergen/EnderMonitorTileEntity.java
+++ b/src/main/java/mcjty/rftools/blocks/endergen/EnderMonitorTileEntity.java
@@ -2,6 +2,7 @@ package mcjty.rftools.blocks.endergen;
 
 import mcjty.lib.tileentity.LogicTileEntity;
 import mcjty.lib.gui.widgets.ChoiceLabel;
+import mcjty.rftools.TickOrderHandler;
 import mcjty.theoneprobe.api.IProbeHitData;
 import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.ProbeMode;
@@ -22,7 +23,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 
 import java.util.List;
 
-public class EnderMonitorTileEntity extends LogicTileEntity implements ITickable {
+public class EnderMonitorTileEntity extends LogicTileEntity implements ITickable, TickOrderHandler.ICheckStateServer {
 
     public static final String CMD_MODE = "endermonitor.setMode";
 
@@ -58,11 +59,12 @@ public class EnderMonitorTileEntity extends LogicTileEntity implements ITickable
     @Override
     public void update() {
         if (!getWorld().isRemote) {
-            checkStateServer();
+            TickOrderHandler.queueEnderMonitor(this);
         }
     }
 
-    private void checkStateServer() {
+    @Override
+    public void checkStateServer() {
         int newout = 0;
 
         if (needpulse) {

--- a/src/main/java/mcjty/rftools/blocks/endergen/PearlInjectorTileEntity.java
+++ b/src/main/java/mcjty/rftools/blocks/endergen/PearlInjectorTileEntity.java
@@ -6,6 +6,7 @@ import mcjty.lib.container.InventoryHelper;
 import mcjty.lib.tileentity.GenericTileEntity;
 import mcjty.lib.varia.OrientationTools;
 import mcjty.rftools.RFTools;
+import mcjty.rftools.TickOrderHandler;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
@@ -17,7 +18,7 @@ import net.minecraft.util.ITickable;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 
-public class PearlInjectorTileEntity extends GenericTileEntity implements DefaultSidedInventory, ITickable {
+public class PearlInjectorTileEntity extends GenericTileEntity implements DefaultSidedInventory, ITickable, TickOrderHandler.ICheckStateServer {
 
     public static final ContainerFactory CONTAINER_FACTORY = new ContainerFactory(new ResourceLocation(RFTools.MODID, "gui/pearl_injector.gui"));
 
@@ -56,11 +57,12 @@ public class PearlInjectorTileEntity extends GenericTileEntity implements Defaul
     @Override
     public void update() {
         if (!getWorld().isRemote) {
-            checkStateServer();
+            TickOrderHandler.queuePearlInjector(this);
         }
     }
 
-    private void checkStateServer() {
+    @Override
+    public void checkStateServer() {
         boolean pulse = (powerLevel > 0) && !prevIn;
         if (prevIn == powerLevel > 0) {
             return;

--- a/src/main/java/mcjty/rftools/blocks/logic/sequencer/SequencerTileEntity.java
+++ b/src/main/java/mcjty/rftools/blocks/logic/sequencer/SequencerTileEntity.java
@@ -7,6 +7,7 @@ import mcjty.lib.gui.widgets.TextField;
 import mcjty.lib.typed.Key;
 import mcjty.lib.typed.Type;
 import mcjty.lib.typed.TypedMap;
+import mcjty.rftools.TickOrderHandler;
 import mcjty.rftools.theoneprobe.TheOneProbeSupport;
 import mcjty.theoneprobe.api.ElementAlignment;
 import mcjty.theoneprobe.api.IProbeHitData;
@@ -21,7 +22,7 @@ import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.common.Optional;
 
-public class SequencerTileEntity extends LogicTileEntity implements ITickable {
+public class SequencerTileEntity extends LogicTileEntity implements ITickable, TickOrderHandler.ICheckStateServer {
 
     public static final String CMD_MODE = "sequencer.mode";
     public static final String CMD_FLIPBITS = "sequencer.flipBits";
@@ -136,12 +137,12 @@ public class SequencerTileEntity extends LogicTileEntity implements ITickable {
     @Override
     public void update() {
         if (!getWorld().isRemote) {
-            checkStateServer();
+            TickOrderHandler.queueSequencer(this);
         }
     }
 
-    private void checkStateServer() {
-
+    @Override
+    public void checkStateServer() {
         boolean pulse = (powerLevel > 0) && !prevIn;
         prevIn = powerLevel > 0;
 

--- a/src/main/java/mcjty/rftools/blocks/logic/timer/TimerTileEntity.java
+++ b/src/main/java/mcjty/rftools/blocks/logic/timer/TimerTileEntity.java
@@ -3,6 +3,7 @@ package mcjty.rftools.blocks.logic.timer;
 import mcjty.lib.tileentity.LogicTileEntity;
 import mcjty.lib.gui.widgets.TextField;
 import mcjty.lib.gui.widgets.ToggleButton;
+import mcjty.rftools.TickOrderHandler;
 import mcjty.theoneprobe.api.IProbeHitData;
 import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.ProbeMode;
@@ -16,7 +17,7 @@ import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.common.Optional;
 
-public class TimerTileEntity extends LogicTileEntity implements ITickable {
+public class TimerTileEntity extends LogicTileEntity implements ITickable, TickOrderHandler.ICheckStateServer {
 
     public static final String CMD_SETDELAY = "timer.setDelay";
     public static final String CMD_SETPAUSES = "timer.setPauses";
@@ -60,11 +61,12 @@ public class TimerTileEntity extends LogicTileEntity implements ITickable {
     @Override
     public void update() {
         if (!getWorld().isRemote) {
-            checkStateServer();
+            TickOrderHandler.queueTimer(this);
         }
     }
 
-    private void checkStateServer() {
+    @Override
+    public void checkStateServer() {
         boolean pulse = (powerLevel > 0) && !prevIn;
         prevIn = powerLevel > 0;
 


### PR DESCRIPTION
As endergenic setups still break even within a chunk on load I thought of an intuitive solution for deterministic and known tick order for the tile entities typically utilized in endergenic setups. I came up with the following order:

1. Pearl Injectors
1. Endergenics in connection order
1. Unconnected endergenics
1. Sequencers
1. Timers
1. Ender Monitors

For pearls this ensures a 0 tick delay except for the last endergenic in a chain which has a 1 tick delay to the endergenic with the injector. The order is undefined if and only if more than one pearl injector is connected to a single endergenic loop. It is possible to have a consistent delay of 1 tick for all endergenics by reversing their tick order but I decided against it because it both slows down the setup a lot and is unintuitive.

For the logic blocks this evaluation order leads to exactly 1 tick delay for:

- Ender Monitor -> Pearl Injector, Endergenic, Sequencer, Timer
- Timer -> Pearl Injector, Endergenic, Sequencer
- Sequencer -> Pearl Injector, Endergenic

As redstone ticks before all of the delayed entities there is 0 delay with a direct connection and 1 tick delay with a redstone connection for:

- Sequencer -> Timer

The delay is undefined (0/1) for:

- Sequencer -> Sequencer
- Timer -> Timer

The order was chosen so that actually useful combinations have a consistent delay (of 1).

Everything behaves linear to the number of entities involved except for the endergenics. The calculation of unconnected endergenics is in O(n^2). This can be improved to O(n) using a LinkedHashSet but the treshold for it to actually be faster should be pretty high.

I built an endergenic setup with this patch and it works independent of placement order, chunk borders or world reload. Hooray.