### PR TITLE
Add sort button to storage scanner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ eclipse/
 .vscode/
 .settings/
 .project
+.classpath
+*.launch
 out/
 bin/
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *.ipr
 *.iws
 eclipse/
+.vscode/
+.settings/
+.project
 out/
 bin/
 .idea/

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ dependencies {
     deobfCompile "cofh:RedstoneFlux:${redstoneflux_version}"
     deobfCompile "net.darkhax.tesla:Tesla-${tesla_version}"
     //deobfCompile "pl.asie.charset:charset:0.5.0.164"
-    compile "team.chisel.ctm:CTM:MC1.12-0.2.3.12"
+    compile "team.chisel.ctm:CTM:MC1.12.2-1.0.1.30"
 
     deobfCompile "com.github.mcjty:intwheel:${intwheel_version}"
     if (!project.hasProperty("singleproject")) {

--- a/src/main/java/mcjty/rftools/blocks/storagemonitor/GuiStorageScanner.java
+++ b/src/main/java/mcjty/rftools/blocks/storagemonitor/GuiStorageScanner.java
@@ -48,6 +48,8 @@ public class GuiStorageScanner extends GenericGuiContainer<StorageScannerTileEnt
     private static final ResourceLocation iconLocation = new ResourceLocation(RFTools.MODID, "textures/gui/storagescanner.png");
     private static final ResourceLocation guielements = new ResourceLocation(RFTools.MODID, "textures/gui/guielements.png");
 
+    private static final ItemSorter[] itemSorters = {new CountItemSorter(), new NameItemSorter()};
+
     private WidgetList storageList;
     private WidgetList itemList;
     private ToggleButton openViewButton;
@@ -161,7 +163,12 @@ public class GuiStorageScanner extends GenericGuiContainer<StorageScannerTileEnt
         });
         sortMode = new ImageChoiceLabel(mc, this)
             .setTooltips("Control how items are sorted", "in the view")
+            .setDesiredWidth(16)
+            .setDesiredHeight(16)
             .addChoiceEvent((parent, newChoice) -> updateSortMode());
+        for (ItemSorter sorter : itemSorters) {
+            sortMode.addChoice(sorter.getName(), sorter.getTooltip(), guielements, sorter.getU(), sorter.getV());
+        }
         Panel searchPanel = new Panel(mc, this)
                 .setLayoutHint(new PositionalLayout.PositionalHint(8, 142, 256 - 11, 18))
                 .setLayout(new HorizontalLayout()).setDesiredHeight(18)
@@ -447,8 +454,7 @@ public class GuiStorageScanner extends GenericGuiContainer<StorageScannerTileEnt
         String sortName = sortMode.getCurrentChoice();
         sortMode.clear();
         
-        ItemSorter[] sorters = {new CountItemSorter(), new NameItemSorter()};
-        for (ItemSorter sorter : sorters) {
+        for (ItemSorter sorter : itemSorters) {
             sortMode.addChoice(sorter.getName(), sorter.getTooltip(), guielements, sorter.getU(), sorter.getV());
         }
         
@@ -457,7 +463,7 @@ public class GuiStorageScanner extends GenericGuiContainer<StorageScannerTileEnt
             sort = 0;
         }
         sortMode.setCurrentChoice(sort);
-        return sorters[sort];
+        return itemSorters[sort];
     }
 
     private Pair<Panel, Integer> addItemToList(ItemStack item, WidgetList itemList, Pair<Panel, Integer> currentPos, int numcolumns, int spacing) {

--- a/src/main/java/mcjty/rftools/blocks/storagemonitor/StorageScannerTileEntity.java
+++ b/src/main/java/mcjty/rftools/blocks/storagemonitor/StorageScannerTileEntity.java
@@ -61,10 +61,12 @@ public class StorageScannerTileEntity extends GenericEnergyReceiverTileEntity im
     public static final String CMD_REMOVE = "scanner.remove";
     public static final String CMD_TOGGLEROUTABLE = "scanner.toggleRoutable";
     public static final String CMD_SETVIEW = "scanner.setView";
+    public static final String CMD_UPDATESORTMODE = "scanner.updateSortMode";
 
     public static final Key<Integer> PARAM_INDEX = new Key<>("index", Type.INTEGER);
     public static final Key<BlockPos> PARAM_POS = new Key<>("pos", Type.BLOCKPOS);
     public static final Key<Boolean> PARAM_VIEW = new Key<>("view", Type.BOOLEAN);
+    public static final Key<String> PARAM_SORTMODE = new Key<>("sortmode", Type.STRING);
 
     public static final String ACTION_CLEARGRID = "clearGrid";
 
@@ -74,6 +76,8 @@ public class StorageScannerTileEntity extends GenericEnergyReceiverTileEntity im
     // Client side data returned by CMD_SCANNER_INFO
     public static long rfReceived = 0;
     public static boolean exportToCurrentReceived = false;
+    
+    private String sortMode = "";
 
     @Override
     public IAction[] getActions() {
@@ -479,7 +483,7 @@ public class StorageScannerTileEntity extends GenericEnergyReceiverTileEntity im
             return s -> s.getDisplayName().toLowerCase().contains(split);
         }
     }
-
+    
     public int getRadius() {
         return radius;
     }
@@ -1030,6 +1034,7 @@ public class StorageScannerTileEntity extends GenericEnergyReceiverTileEntity im
         readBufferFromNBT(tagCompound, inventoryHelper);
         radius = tagCompound.getInteger("radius");
         exportToCurrent = tagCompound.getBoolean("exportC");
+        sortMode = tagCompound.getString("sortMode");
         if (tagCompound.hasKey("wideview")) {
             openWideView = tagCompound.getBoolean("wideview");
         } else {
@@ -1069,6 +1074,7 @@ public class StorageScannerTileEntity extends GenericEnergyReceiverTileEntity im
         tagCompound.setInteger("radius", radius);
         tagCompound.setBoolean("exportC", exportToCurrent);
         tagCompound.setBoolean("wideview", openWideView);
+        tagCompound.setString("sortMode", sortMode);
         tagCompound.setTag("grid", craftingGrid.writeToNBT());
     }
 
@@ -1106,6 +1112,9 @@ public class StorageScannerTileEntity extends GenericEnergyReceiverTileEntity im
             return true;
         } else if (CMD_SETVIEW.equals(command)) {
             setOpenWideView(params.get(PARAM_VIEW));
+            return true;
+        } else if (CMD_UPDATESORTMODE.equals(command)) {
+            setSortMode(params.get(PARAM_SORTMODE));
             return true;
         }
         return false;
@@ -1224,5 +1233,14 @@ public class StorageScannerTileEntity extends GenericEnergyReceiverTileEntity im
     @Override
     public int[] getSlotsForFace(EnumFacing side) {
         return SLOTS;
+    }
+
+    public String getSortMode() {
+        return sortMode;
+    }
+
+    public void setSortMode(String sortMode) {
+        this.sortMode = sortMode;
+        markDirty();
     }
 }


### PR DESCRIPTION
### Fixes #1604.

This PR adds a button in the storage scanner GUI that sorts by name or by count:

![grafik](https://user-images.githubusercontent.com/30873659/74616767-115ceb80-512a-11ea-989c-b86a5950821d.png)
